### PR TITLE
Multi user search and password check functionality

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ dependencies {
     implementation 'ch.qos.logback:logback-classic:1.2.12'
     implementation 'ch.qos.logback:logback-core:1.2.12'
     implementation 'org.slf4j:jcl-over-slf4j:1.7.36'
-    implementation 'info.picocli:picocli:4.6.1'
+    implementation 'info.picocli:picocli:4.7.5'
     testImplementation 'org.testng:testng:6.10'
 }
 

--- a/src/main/java/com/glencoesoftware/ldaptool/Main.java
+++ b/src/main/java/com/glencoesoftware/ldaptool/Main.java
@@ -20,72 +20,52 @@ package com.glencoesoftware.ldaptool;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.ldap.core.DistinguishedName;
 import org.springframework.ldap.core.LdapTemplate;
 
 import ch.qos.logback.classic.Level;
 import ome.logic.LdapImpl;
-import ome.logic.LdapImpl.GroupLoader;
-import ome.model.meta.Experimenter;
 import ome.system.OmeroContext;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Field;
-import java.util.List;
 import java.util.Properties;
-import java.util.StringJoiner;
-import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import picocli.CommandLine;
-import picocli.CommandLine.ArgGroup;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
-import picocli.CommandLine.Parameters;
+import picocli.CommandLine.ParseResult;
 
 /**
  * @author Chris Allan <callan@glencoesoftware.com>
  */
-@Command(exitCodeOnExecutionException = 100)
-public class Main implements Callable<Integer>
+@Command(
+    mixinStandardHelpOptions = true,
+    subcommands = Search.class,
+    exitCodeOnExecutionException = 100
+)
+public class Main
 {
     private static final Logger log =
             LoggerFactory.getLogger(Main.class);
 
     @Option(
-        names = "--help",
-        usageHelp = true,
-        description = "Display this help and exit"
+        names = "--log-level",
+        description = "Change logging level; valid values are " +
+            "OFF, ERROR, WARN, INFO, DEBUG, TRACE and ALL. " +
+            "(default: ${DEFAULT-VALUE})"
     )
-    boolean help;
-
-    @Option(
-            names = "--log-level",
-            description = "Change logging level; valid values are " +
-              "OFF, ERROR, WARN, INFO, DEBUG, TRACE and ALL. " +
-              "(default: ${DEFAULT-VALUE})"
-          )
     String logLevel = "WARN";
 
-    @ArgGroup(exclusive = true, multiplicity = "1")
-    SearchFor searchFor;
-
-    static class SearchFor {
-        @Option(names = "--all", description = "Print all users")
-        boolean all;
-
-        @Option(names = "--user", description = "Username to search")
-        String[] username;
-    }
-
-    @Parameters(
-        index = "0",
-        description = "LDAP configuration properties file"
+    @Option(
+        names = "--config",
+        description = "LDAP configuration properties file",
+        required = true
     )
     File config;
 
     // Non-CLI fields
+    OmeroContext context;
     LdapImpl ldapImpl;
     LdapTemplate ldapTemplate;
 
@@ -93,23 +73,31 @@ public class Main implements Callable<Integer>
 
     public static void main(String[] args)
     {
-        int exitCode = new CommandLine(new Main()).execute(args);
+        Main main = new Main();
+        int exitCode = new CommandLine(main)
+                .setExecutionStrategy(main::executionStrategy)
+                .execute(args);
         System.exit(exitCode);
     }
 
-    public GroupLoader newGroupLoader(
-            LdapImpl ldapImpl, String username, DistinguishedName dn)
-                    throws Exception {
-        Class<?> clazz = Class.forName("ome.logic.LdapImpl$GroupLoader");
-        Constructor<?> constructor =
-            clazz.getDeclaredConstructor(
-                    LdapImpl.class, String.class, DistinguishedName.class);
-        constructor.setAccessible(true);
-        return (GroupLoader) constructor.newInstance(ldapImpl, username, dn);
+    private int executionStrategy(ParseResult parseResult) {
+        // Check if any subcommands have usage help or version help requested
+        AtomicBoolean doInit = new AtomicBoolean(true);
+        parseResult.subcommands().forEach(v -> {
+            if (v.isUsageHelpRequested() || v.isVersionHelpRequested()) {
+                doInit.set(false);
+            }
+        });
+
+        if (doInit.get()
+                && !parseResult.isUsageHelpRequested()
+                && !parseResult.isVersionHelpRequested()) {
+            init();
+        }
+        return new CommandLine.RunLast().execute(parseResult);
     }
 
-    @Override
-    public Integer call() throws Exception {
+    public void init() {
         ch.qos.logback.classic.Logger root = (ch.qos.logback.classic.Logger)
                 LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
         root.setLevel(Level.toLevel(logLevel));
@@ -121,87 +109,16 @@ public class Main implements Callable<Integer>
             properties.load(v);
             log.info("Properties: {}", properties);
             System.setProperties(properties);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
         }
 
-        OmeroContext context = new OmeroContext(new String[]{
+        context = new OmeroContext(new String[]{
                 "classpath:ome/config.xml",
                 "classpath:ome/services/datalayer.xml",
                 "classpath*:beanRefContext.xml"});
-
         ldapImpl = (LdapImpl) context.getBean("internal-ome.api.ILdap");
         ldapTemplate = (LdapTemplate) context.getBean("ldapTemplate");
-        String referral = context.getProperty("omero.ldap.referral");
-        Field ignorePartialResultException =
-                LdapTemplate.class.getDeclaredField("ignorePartialResultException");
-        ignorePartialResultException.setAccessible(true);
-        log.info("Ignoring partial result exceptions? {}",
-                ignorePartialResultException.get(ldapTemplate));
-        log.info("Referral set to: '{}'", referral);
-
-        System.out.println("---");
-        if (searchFor.all) {
-            lookupAllUsers(ldapImpl, ldapTemplate);
-        } else {
-            for (String username : searchFor.username) {
-                try {
-                    Experimenter experimenter =
-                            ldapImpl.findExperimenter(username);
-                    lookupUser(ldapImpl, ldapTemplate, experimenter);
-                } catch (ome.conditions.ApiUsageException api) {
-                    System.err.println("no such user: " + searchFor.username);
-                    return 1;
-                }
-            }
-        }
-        return 0;
-    }
-
-    public void lookupAllUsers(LdapImpl ldapImpl, LdapTemplate ldapTemplate) throws Exception {
-        List<Experimenter> users = ldapImpl.searchAll();
-        for (Experimenter user : users) {
-            lookupUser(ldapImpl, ldapTemplate, user);
-        }
-    }
-
-    public void lookupUser(LdapImpl ldapImpl, LdapTemplate template, Experimenter user) throws Exception {
-
-        String dn = (String) user.retrieve("LDAP_DN");
-
-        // This class needs updating in omero-server to make it also return strings
-        GroupLoader groupLoader = newGroupLoader(
-                ldapImpl, user.getOmeName(), new DistinguishedName(dn));
-        Field groups = LdapImpl.GroupLoader.class.getDeclaredField("groups");
-        groups.setAccessible(true);
-        printString("- dn", dn);
-        printString("  omeName", user.getOmeName());
-        printString("  firstName", user.getFirstName());
-        printString("  middleName", user.getMiddleName());
-        printString("  lastName", user.getLastName());
-        printString("  email", user.getEmail());
-        printString("  institution", user.getInstitution());
-        printGroup("owner", groupLoader.getOwnedGroups());
-        printGroup("member", (List<Long>) groups.get(groupLoader));
-
-    }
-
-    private void printString(String key, String value) {
-        if (value == null) {
-            return;
-        }
-        value = '"' + value + '"';
-        System.out.println(String.format("%s: %s", key, value));
-    }
-
-    private void printGroup(String key, List<Long> groups) {
-        if (groups == null || groups.size() == 0) {
-            return;
-        }
-
-        StringJoiner joiner = new StringJoiner(", ");
-        for (Long id : groups) {
-            joiner.add(id.toString());
-        }
-        System.out.println(String.format("  %s: [%s]", key, joiner.toString()));
     }
 
 }

--- a/src/main/java/com/glencoesoftware/ldaptool/Main.java
+++ b/src/main/java/com/glencoesoftware/ldaptool/Main.java
@@ -40,12 +40,14 @@ import java.util.concurrent.Callable;
 
 import picocli.CommandLine;
 import picocli.CommandLine.ArgGroup;
+import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
 
 /**
  * @author Chris Allan <callan@glencoesoftware.com>
  */
+@Command(exitCodeOnExecutionException = 100)
 public class Main implements Callable<Integer>
 {
     private static final Logger log =
@@ -91,14 +93,8 @@ public class Main implements Callable<Integer>
 
     public static void main(String[] args)
     {
-        Integer returnCode;
-        try {
-            returnCode = CommandLine.call(new Main(), args);
-        } catch (Exception e) {
-            log.error("Error when calling command", e);
-            returnCode = 1;
-        }
-        System.exit(returnCode == null? 100 : returnCode);
+        int exitCode = new CommandLine(new Main()).execute(args);
+        System.exit(exitCode);
     }
 
     public GroupLoader newGroupLoader(

--- a/src/main/java/com/glencoesoftware/ldaptool/Main.java
+++ b/src/main/java/com/glencoesoftware/ldaptool/Main.java
@@ -41,9 +41,11 @@ import picocli.CommandLine.ScopeType;
  * @author Chris Allan <callan@glencoesoftware.com>
  */
 @Command(
+    name = "omero-ldaptool",
     mixinStandardHelpOptions = true,
     subcommands = {Password.class, Search.class},
-    exitCodeOnExecutionException = 100
+    exitCodeOnExecutionException = 100,
+    versionProvider = VersionProvider.class
 )
 public class Main
 {
@@ -123,5 +125,4 @@ public class Main
         ldapImpl = (LdapImpl) context.getBean("internal-ome.api.ILdap");
         ldapTemplate = (LdapTemplate) context.getBean("ldapTemplate");
     }
-
 }

--- a/src/main/java/com/glencoesoftware/ldaptool/Main.java
+++ b/src/main/java/com/glencoesoftware/ldaptool/Main.java
@@ -76,7 +76,7 @@ public class Main implements Callable<Integer>
         boolean all;
 
         @Option(names = "--user", description = "Username to search")
-        String username;
+        String[] username;
     }
 
     @Parameters(
@@ -142,12 +142,15 @@ public class Main implements Callable<Integer>
         if (searchFor.all) {
             lookupAllUsers(ldapImpl, ldapTemplate);
         } else {
-            try {
-                Experimenter experimenter = ldapImpl.findExperimenter(searchFor.username);
-                lookupUser(ldapImpl, ldapTemplate, experimenter);
-            } catch (ome.conditions.ApiUsageException api) {
-                System.err.println("no such user: " + searchFor.username);
-                return 1;
+            for (String username : searchFor.username) {
+                try {
+                    Experimenter experimenter =
+                            ldapImpl.findExperimenter(username);
+                    lookupUser(ldapImpl, ldapTemplate, experimenter);
+                } catch (ome.conditions.ApiUsageException api) {
+                    System.err.println("no such user: " + searchFor.username);
+                    return 1;
+                }
             }
         }
         return 0;

--- a/src/main/java/com/glencoesoftware/ldaptool/Main.java
+++ b/src/main/java/com/glencoesoftware/ldaptool/Main.java
@@ -35,6 +35,7 @@ import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.ParseResult;
+import picocli.CommandLine.ScopeType;
 
 /**
  * @author Chris Allan <callan@glencoesoftware.com>
@@ -53,14 +54,16 @@ public class Main
         names = "--log-level",
         description = "Change logging level; valid values are " +
             "OFF, ERROR, WARN, INFO, DEBUG, TRACE and ALL. " +
-            "(default: ${DEFAULT-VALUE})"
+            "(default: ${DEFAULT-VALUE})",
+        scope = ScopeType.INHERIT
     )
     String logLevel = "WARN";
 
     @Option(
         names = "--config",
         description = "LDAP configuration properties file",
-        required = true
+        required = true,
+        scope = ScopeType.INHERIT
     )
     File config;
 

--- a/src/main/java/com/glencoesoftware/ldaptool/Main.java
+++ b/src/main/java/com/glencoesoftware/ldaptool/Main.java
@@ -41,7 +41,7 @@ import picocli.CommandLine.ParseResult;
  */
 @Command(
     mixinStandardHelpOptions = true,
-    subcommands = Search.class,
+    subcommands = {Password.class, Search.class},
     exitCodeOnExecutionException = 100
 )
 public class Main

--- a/src/main/java/com/glencoesoftware/ldaptool/Main.java
+++ b/src/main/java/com/glencoesoftware/ldaptool/Main.java
@@ -33,7 +33,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
 import java.util.StringJoiner;

--- a/src/main/java/com/glencoesoftware/ldaptool/Password.java
+++ b/src/main/java/com/glencoesoftware/ldaptool/Password.java
@@ -49,6 +49,14 @@ public class Password implements Callable<Integer>
     )
     String password;
 
+    @Option(
+        names = {"--tries"},
+        description =
+            "Number of times to retry the password check " +
+            "(default: ${DEFAULT-VALUE})"
+    )
+    int tries = 1;
+
     @Parameters(
         index = "0",
         description = "DN to check password for"
@@ -62,12 +70,16 @@ public class Password implements Callable<Integer>
 
     @Override
     public Integer call() throws Exception {
-        if (main.ldapImpl.validatePassword(dn, password)) {
-            System.out.println("Password check successful!");
-            return 0;
+        int exitCode = 0;
+        for (int i = 0; i < tries; i++) {
+            if (main.ldapImpl.validatePassword(dn, password)) {
+                System.out.println("Password check successful!");
+            } else {
+                System.out.println("Password check failed!");
+                exitCode = 1;
+            }
         }
-        System.out.println("Password check failed!");
-        return 1;
+        return exitCode;
     }
 
 }

--- a/src/main/java/com/glencoesoftware/ldaptool/Password.java
+++ b/src/main/java/com/glencoesoftware/ldaptool/Password.java
@@ -34,7 +34,8 @@ import picocli.CommandLine.ParentCommand;
 @Command(
     name = "password",
     mixinStandardHelpOptions = true,
-    exitCodeOnExecutionException = 100
+    exitCodeOnExecutionException = 100,
+    versionProvider = VersionProvider.class
 )
 public class Password implements Callable<Integer>
 {

--- a/src/main/java/com/glencoesoftware/ldaptool/Password.java
+++ b/src/main/java/com/glencoesoftware/ldaptool/Password.java
@@ -42,14 +42,6 @@ public class Password implements Callable<Integer>
             LoggerFactory.getLogger(Password.class);
 
     @Option(
-        names = {"-p", "--password"},
-        description = "Passphrase",
-        interactive = true,
-        required = true
-    )
-    String password;
-
-    @Option(
         names = {"--tries"},
         description =
             "Number of times to retry the password check " +
@@ -70,9 +62,11 @@ public class Password implements Callable<Integer>
 
     @Override
     public Integer call() throws Exception {
+        String passphrase = String.valueOf(System.console().readPassword(
+                "Enter passphrase for '" + dn + "': "));
         int exitCode = 0;
         for (int i = 0; i < tries; i++) {
-            if (main.ldapImpl.validatePassword(dn, password)) {
+            if (main.ldapImpl.validatePassword(dn, passphrase)) {
                 System.out.println("Password check successful!");
             } else {
                 System.out.println("Password check failed!");

--- a/src/main/java/com/glencoesoftware/ldaptool/Password.java
+++ b/src/main/java/com/glencoesoftware/ldaptool/Password.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2023 Glencoe Software, Inc. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package com.glencoesoftware.ldaptool;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.Callable;
+
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
+import picocli.CommandLine.ParentCommand;
+
+/**
+ * @author Chris Allan <callan@glencoesoftware.com>
+ */
+@Command(
+    name = "password",
+    mixinStandardHelpOptions = true,
+    exitCodeOnExecutionException = 100
+)
+public class Password implements Callable<Integer>
+{
+    private static final Logger log =
+            LoggerFactory.getLogger(Password.class);
+
+    @Option(
+        names = {"-p", "--password"},
+        description = "Passphrase",
+        interactive = true,
+        required = true
+    )
+    String password;
+
+    @Parameters(
+        index = "0",
+        description = "DN to check password for"
+    )
+    String dn;
+
+    @ParentCommand
+    private Main main;
+
+    Password() { }
+
+    @Override
+    public Integer call() throws Exception {
+        if (main.ldapImpl.validatePassword(dn, password)) {
+            System.out.println("Password check successful!");
+            return 0;
+        }
+        System.out.println("Password check failed!");
+        return 1;
+    }
+
+}

--- a/src/main/java/com/glencoesoftware/ldaptool/Search.java
+++ b/src/main/java/com/glencoesoftware/ldaptool/Search.java
@@ -87,7 +87,7 @@ public class Search implements Callable<Integer>
                             main.ldapImpl.findExperimenter(username);
                     lookupUser(main.ldapImpl, main.ldapTemplate, experimenter);
                 } catch (ome.conditions.ApiUsageException api) {
-                    System.err.println("no such user: " + searchFor.username);
+                    System.err.println("no such user: " + username);
                     return 1;
                 }
             }

--- a/src/main/java/com/glencoesoftware/ldaptool/Search.java
+++ b/src/main/java/com/glencoesoftware/ldaptool/Search.java
@@ -44,7 +44,8 @@ import picocli.CommandLine.ParentCommand;
 @Command(
     name = "search",
     mixinStandardHelpOptions = true,
-    exitCodeOnExecutionException = 100
+    exitCodeOnExecutionException = 100,
+    versionProvider = VersionProvider.class
 )
 public class Search implements Callable<Integer>
 {

--- a/src/main/java/com/glencoesoftware/ldaptool/Search.java
+++ b/src/main/java/com/glencoesoftware/ldaptool/Search.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright (C) 2019 Glencoe Software, Inc. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package com.glencoesoftware.ldaptool;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.ldap.core.DistinguishedName;
+import org.springframework.ldap.core.LdapTemplate;
+
+import ome.logic.LdapImpl;
+import ome.logic.LdapImpl.GroupLoader;
+import ome.model.meta.Experimenter;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.StringJoiner;
+import java.util.concurrent.Callable;
+
+import picocli.CommandLine.ArgGroup;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.ParentCommand;
+
+/**
+ * @author Chris Allan <callan@glencoesoftware.com>
+ */
+@Command(
+    name = "search",
+    mixinStandardHelpOptions = true,
+    exitCodeOnExecutionException = 100
+)
+public class Search implements Callable<Integer>
+{
+    private static final Logger log =
+            LoggerFactory.getLogger(Search.class);
+
+    @ArgGroup(exclusive = true, multiplicity = "1")
+    SearchFor searchFor;
+
+    static class SearchFor {
+        @Option(names = "--all", description = "Print all users")
+        boolean all;
+
+        @Option(names = "--user", description = "Username to search")
+        String[] username;
+    }
+
+    @ParentCommand
+    private Main main;
+
+    Search() { }
+
+    @Override
+    public Integer call() throws Exception {
+        String referral = main.context.getProperty("omero.ldap.referral");
+        Field ignorePartialResultException =
+                LdapTemplate.class.getDeclaredField("ignorePartialResultException");
+        ignorePartialResultException.setAccessible(true);
+        log.info("Ignoring partial result exceptions? {}",
+                ignorePartialResultException.get(main.ldapTemplate));
+        log.info("Referral set to: '{}'", referral);
+
+        System.out.println("---");
+        if (searchFor.all) {
+            lookupAllUsers(main.ldapImpl, main.ldapTemplate);
+        } else {
+            for (String username : searchFor.username) {
+                try {
+                    Experimenter experimenter =
+                            main.ldapImpl.findExperimenter(username);
+                    lookupUser(main.ldapImpl, main.ldapTemplate, experimenter);
+                } catch (ome.conditions.ApiUsageException api) {
+                    System.err.println("no such user: " + searchFor.username);
+                    return 1;
+                }
+            }
+        }
+        return 0;
+    }
+
+    private GroupLoader newGroupLoader(
+            LdapImpl ldapImpl, String username, DistinguishedName dn)
+                    throws Exception {
+        Class<?> clazz = Class.forName("ome.logic.LdapImpl$GroupLoader");
+        Constructor<?> constructor =
+            clazz.getDeclaredConstructor(
+                    LdapImpl.class, String.class, DistinguishedName.class);
+        constructor.setAccessible(true);
+        return (GroupLoader) constructor.newInstance(ldapImpl, username, dn);
+    }
+
+    private void lookupAllUsers(LdapImpl ldapImpl, LdapTemplate ldapTemplate) throws Exception {
+        List<Experimenter> users = ldapImpl.searchAll();
+        for (Experimenter user : users) {
+            lookupUser(ldapImpl, ldapTemplate, user);
+        }
+    }
+
+    private void lookupUser(LdapImpl ldapImpl, LdapTemplate template, Experimenter user) throws Exception {
+        String dn = (String) user.retrieve("LDAP_DN");
+
+        // This class needs updating in omero-server to make it also return strings
+        GroupLoader groupLoader = newGroupLoader(
+                ldapImpl, user.getOmeName(), new DistinguishedName(dn));
+        Field groups = LdapImpl.GroupLoader.class.getDeclaredField("groups");
+        groups.setAccessible(true);
+        printString("- dn", dn);
+        printString("  omeName", user.getOmeName());
+        printString("  firstName", user.getFirstName());
+        printString("  middleName", user.getMiddleName());
+        printString("  lastName", user.getLastName());
+        printString("  email", user.getEmail());
+        printString("  institution", user.getInstitution());
+        printGroup("owner", groupLoader.getOwnedGroups());
+        printGroup("member", (List<Long>) groups.get(groupLoader));
+
+    }
+
+    private void printString(String key, String value) {
+        if (value == null) {
+            return;
+        }
+        value = '"' + value + '"';
+        System.out.println(String.format("%s: %s", key, value));
+    }
+
+    private void printGroup(String key, List<Long> groups) {
+        if (groups == null || groups.size() == 0) {
+            return;
+        }
+
+        StringJoiner joiner = new StringJoiner(", ");
+        for (Long id : groups) {
+            joiner.add(id.toString());
+        }
+        System.out.println(String.format("  %s: [%s]", key, joiner.toString()));
+    }
+
+}

--- a/src/main/java/com/glencoesoftware/ldaptool/VersionProvider.java
+++ b/src/main/java/com/glencoesoftware/ldaptool/VersionProvider.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2019 Glencoe Software, Inc. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+package com.glencoesoftware.ldaptool;
+
+import java.util.Optional;
+
+import ome.services.blitz.Entry;
+import picocli.CommandLine.IVersionProvider;
+
+class VersionProvider implements IVersionProvider {
+
+    @Override
+    public String[] getVersion() throws Exception {
+        String version = Optional.ofNullable(
+            this.getClass().getPackage().getImplementationVersion()
+        ).orElse("development");
+        String blitzVersion = Optional.ofNullable(
+            Entry.class.getPackage().getImplementationVersion()
+        ).orElse("development");
+        return new String[] {
+            "${COMMAND-FULL-NAME} version " + version,
+            "omero-blitz version " + blitzVersion
+        };
+    }
+
+}


### PR DESCRIPTION
Expands the search capabilities of the tool with a completely new subcommand driven interface. This now includes the ability to perform password checks in a manner similar to the server. New help:

```
Usage: <main class> [-hV] --config=<config> [--log-level=<logLevel>] [COMMAND]
      --config=<config>   LDAP configuration properties file
  -h, --help              Show this help message and exit.
      --log-level=<logLevel>
                          Change logging level; valid values are OFF, ERROR,
                            WARN, INFO, DEBUG, TRACE and ALL. (default: WARN)
  -V, --version           Print version information and exit.
Commands:
  password
  search
```

```
Usage: <main class> search [-hV] (--all | --user=<username>
                           [--user=<username>]...)
      --all               Print all users
  -h, --help              Show this help message and exit.
      --user=<username>   Username to search
  -V, --version           Print version information and exit.
```

```
Usage: <main class> password [-hV] -p [--tries=<tries>] <dn>
      <dn>              DN to check password for
  -h, --help            Show this help message and exit.
  -p, --password        Passphrase
      --tries=<tries>   Number of times to retry the password check (default: 1)
  -V, --version         Print version information and exit.
```

Example:

`omero-ldaptool --log-level=ALL --user callan config.properties`

is now...

`omero-ldaptool --log-level=ALL --config config.properties search --user callan`