### PR TITLE
Configuration Escaping

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     strategy:
       matrix:
-        java: [8, 11]
+        java: [11, 17]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Requirements
 ============
 
 * OMERO 5.6.x+
-* Java 8+
+* Java 11+
 
 Workflow
 ========

--- a/build.gradle
+++ b/build.gradle
@@ -9,8 +9,9 @@ version = '0.3.1-SNAPSHOT'
 
 mainClassName = 'com.glencoesoftware.ldaptool.Main'
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+compileJava {
+    options.release = 11
+}
 
 repositories {
     mavenCentral()

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/com/glencoesoftware/ldaptool/Main.java
+++ b/src/main/java/com/glencoesoftware/ldaptool/Main.java
@@ -26,8 +26,11 @@ import ch.qos.logback.classic.Level;
 import ome.logic.LdapImpl;
 import ome.system.OmeroContext;
 
-import java.io.File;
-import java.io.FileInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -67,7 +70,7 @@ public class Main
         required = true,
         scope = ScopeType.INHERIT
     )
-    File config;
+    Path config;
 
     // Non-CLI fields
     OmeroContext context;
@@ -97,26 +100,33 @@ public class Main
         if (doInit.get()
                 && !parseResult.isUsageHelpRequested()
                 && !parseResult.isVersionHelpRequested()) {
-            init();
+            try {
+                init();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
         }
         return new CommandLine.RunLast().execute(parseResult);
     }
 
-    public void init() {
+    public void init() throws IOException {
         ch.qos.logback.classic.Logger root = (ch.qos.logback.classic.Logger)
                 LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
         root.setLevel(Level.toLevel(logLevel));
 
-        log.info("Loading LDAP configuration from: {}",
-                config.getAbsolutePath());
-        try (FileInputStream v = new FileInputStream(config)) {
-            Properties properties = System.getProperties();
-            properties.load(v);
-            log.info("Properties: {}", properties);
-            System.setProperties(properties);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+        log.info("Loading LDAP configuration from: {}", config);
+        String asString = Files.readString(config);
+        // Configuration will come out of `omero config get` or similar without
+        // backslash escaping.  If configuration is sourced this way it is
+        // unlikely to be escaped correctly, a Java properties requirement,
+        // before being passed in so we will perform the escaping ourselves.
+        asString = asString.replace("\\", "\\\\");
+        ByteArrayInputStream v = new ByteArrayInputStream(
+                asString.getBytes(StandardCharsets.UTF_8));
+        Properties properties = System.getProperties();
+        properties.load(v);
+        log.info("Properties: {}", properties);
+        System.setProperties(properties);
 
         context = new OmeroContext(new String[]{
                 "classpath:ome/config.xml",

--- a/src/main/java/com/glencoesoftware/ldaptool/Main.java
+++ b/src/main/java/com/glencoesoftware/ldaptool/Main.java
@@ -102,6 +102,8 @@ public class Main
                 && !parseResult.isVersionHelpRequested()) {
             try {
                 init();
+            } catch (RuntimeException re) {
+                throw re;
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }
@@ -133,6 +135,10 @@ public class Main
                 "classpath:ome/services/datalayer.xml",
                 "classpath*:beanRefContext.xml"});
         ldapImpl = (LdapImpl) context.getBean("internal-ome.api.ILdap");
+        if (!ldapImpl.getSetting()) {
+            throw new RuntimeException(
+                    "LDAP is not enabled, is `omero.ldap.config` set?");
+        }
         ldapTemplate = (LdapTemplate) context.getBean("ldapTemplate");
     }
 }


### PR DESCRIPTION
Configuration will come out of `omero config get` or similar without
backslash escaping.  If configuration is sourced this way it is
unlikely to be escaped correctly, a Java properties requirement,
before being passed in so we will perform the escaping ourselves.

This PR also checks if `omero.ldap.config` is set correctly.